### PR TITLE
Reversion to language autodetect

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -3,9 +3,55 @@ from googletrans import Translator, LANGUAGES
 from time import sleep
 import langdetect
 import logging
+from pprint import pprint
 
 # Initializing logging in module
 logger = logging.getLogger(__name__)
+
+# Harddcoded test_list
+test_headline_data = [['Atšaukta didžiausia pasaulyje telekomunikacijų paroda',
+        'https://www.vz.lt/technologijos-mokslas/2020/02/12/atsaukta-didziausia-pasaulyje-telekomunikaciju-paroda'],
+        ['Mato prielaidų šiemet atpigti vairuotojų privalomajam draudimui',
+        'https://www.vz.lt/finansai-apskaita/bankai-draudimas/2020/02/14/mato-prielaidu-siemet-atpigti-vairuotoju-privalomajam-draudimui'],
+        ['Kaip patikrinti, ką darbuotojai išmoko mokymuose',
+        'https://www.vz.lt/smulkusis-verslas/2020/02/13/kaip-patikrinti-ka-darbuotojai-ismoko-mokymuose'],
+        ['Atšaukta didžiausia pasaulyje telekomunikacijų paroda',
+        'https://www.vz.lt/technologijos-mokslas/2020/02/12/atsaukta-didziausia-pasaulyje-telekomunikaciju-paroda'],
+        ['Iškreipta realybė: Graikijos ir Italijos obligacijos graibstomos kaip '
+        'saugumo užuovėja',
+        'https://www.vz.lt/rinkos/2020/02/18/iskreipta-realybe-graikijos-ir-italijos-obligacijos-graibstomos-kaip-saugumo-uzuoveja'],
+        ['Lumenappus sunnib suusakeskuseid lume hankimiseks äärmuslikke viise otsima',
+        'https://www.err.ee/1036324/lumenappus-sunnib-suusakeskuseid-lume-hankimiseks-aarmuslikke-viise-otsima'],
+        ['Soe talv, suvised hinnad: ületootmine ajas maagaasi hinna rekordmadalale',
+        'https://www.err.ee/1036195/soe-talv-suvised-hinnad-uletootmine-ajas-maagaasi-hinna-rekordmadalale'],
+        ['Triin Kutberg: alkoholiaktsiisi langetamine mõjus majandusele positiivselt',
+        'https://www.err.ee/1054639/triin-kutberg-alkoholiaktsiisi-langetamine-mojus-majandusele-positiivselt'],
+        ['Uus Läti-Eesti elektriliin võib tulla Liivi merepargi kaudu',
+        'https://www.err.ee/1036888/uus-lati-eesti-elektriliin-voib-tulla-liivi-merepargi-kaudu'],
+        ['Eesti koos veel kaheksa riigiga kaalub EL-i maanteepaketi tõttu kohtuteed',
+        'https://www.err.ee/1036795/eesti-koos-veel-kaheksa-riigiga-kaalub-el-i-maanteepaketi-tottu-kohtuteed'],
+        ["Belarus orders two more oil tankers via Lithuania's Klaipeda",
+        'https://www.baltictimes.com/belarus_orders_two_more_oil_tankers_via_lithuania_s_klaipeda/'],
+        ["Belarus orders two more oil tankers via Lithuania's Klaipeda",
+        'https://www.baltictimes.com/belarus_orders_two_more_oil_tankers_via_lithuania_s_klaipeda/'],
+        ['Utena brewery is the first in the country to eliminate CO 2 emissions: '
+        'exclusive status granted',
+        'https://www.baltictimes.com/utena_brewery_is_the_first_in_the_country_to_eliminate_co_2_emissions__exclusive_status_granted/'],
+        ['Lithuania chosen as a launchpad to EU markets – Cinganta',
+        'https://www.baltictimes.com/lithuania_chosen_as_a_launchpad_to_eu_markets___cinganta/'],
+        ['Two Latvian citizens convicted of large-scale fraud in the United States',
+        'https://www.baltictimes.com/two_latvian_citizens_convicted_of_large-scale_fraud_in_the_united_states/'],
+        ['Finanšu tehnoloģiju uzņēmumi nolūko Vjetnamu',
+        'https://www.db.lv/zinas/finansu-tehnologiju-uznemumi-noluko-vjetnamu-494934'],
+        ['Maksājumu jomā transformācija turpināsies',
+        'https://www.db.lv/zinas/maksajumu-joma-transformacija-turpinasies-494760'],
+        ['Elektroenerģijas ražotājs AS Residence Energy par labu Meridian Trade Bank '
+        'ieķīlājis visu mantu',
+        'https://www.db.lv/zinas/elektroenergijas-razotajs-as-residence-energy-par-labu-meridian-trade-bank-iekilajis-visu-mantu-494452'],
+        ['Kā top? Ziemeļu Enkurs alus',
+        'https://www.db.lv/zinas/ka-top-ziemelu-enkurs-alus-494781'],
+        ['Twitter ienākumi pārlec miljardam',
+        'https://www.db.lv/zinas/twitter-ienakumi-parlec-miljardam-494804']]
 
 class TranslateList():
     '''Based on googletrans Translator, tailored for project needs. Works on uniform language list only. Takes args:
@@ -138,4 +184,7 @@ class TranslateList():
 
 
 if __name__ == '__main__':
-    pass
+    # pass
+    translator = TranslateList(test_headline_data, ['en'])
+    translated_list = translator.get_translated()
+    pprint(translated_list)

--- a/translate.py
+++ b/translate.py
@@ -1,57 +1,10 @@
 from utils import get_user_agent_str, get_working_proxy, USER_AGENTS
 from googletrans import Translator, LANGUAGES
-from time import sleep
 import langdetect
 import logging
-from pprint import pprint
 
 # Initializing logging in module
 logger = logging.getLogger(__name__)
-
-# Harddcoded test_list
-test_headline_data = [['Atšaukta didžiausia pasaulyje telekomunikacijų paroda',
-        'https://www.vz.lt/technologijos-mokslas/2020/02/12/atsaukta-didziausia-pasaulyje-telekomunikaciju-paroda'],
-        ['Mato prielaidų šiemet atpigti vairuotojų privalomajam draudimui',
-        'https://www.vz.lt/finansai-apskaita/bankai-draudimas/2020/02/14/mato-prielaidu-siemet-atpigti-vairuotoju-privalomajam-draudimui'],
-        ['Kaip patikrinti, ką darbuotojai išmoko mokymuose',
-        'https://www.vz.lt/smulkusis-verslas/2020/02/13/kaip-patikrinti-ka-darbuotojai-ismoko-mokymuose'],
-        ['Atšaukta didžiausia pasaulyje telekomunikacijų paroda',
-        'https://www.vz.lt/technologijos-mokslas/2020/02/12/atsaukta-didziausia-pasaulyje-telekomunikaciju-paroda'],
-        ['Iškreipta realybė: Graikijos ir Italijos obligacijos graibstomos kaip '
-        'saugumo užuovėja',
-        'https://www.vz.lt/rinkos/2020/02/18/iskreipta-realybe-graikijos-ir-italijos-obligacijos-graibstomos-kaip-saugumo-uzuoveja'],
-        ['Lumenappus sunnib suusakeskuseid lume hankimiseks äärmuslikke viise otsima',
-        'https://www.err.ee/1036324/lumenappus-sunnib-suusakeskuseid-lume-hankimiseks-aarmuslikke-viise-otsima'],
-        ['Soe talv, suvised hinnad: ületootmine ajas maagaasi hinna rekordmadalale',
-        'https://www.err.ee/1036195/soe-talv-suvised-hinnad-uletootmine-ajas-maagaasi-hinna-rekordmadalale'],
-        ['Triin Kutberg: alkoholiaktsiisi langetamine mõjus majandusele positiivselt',
-        'https://www.err.ee/1054639/triin-kutberg-alkoholiaktsiisi-langetamine-mojus-majandusele-positiivselt'],
-        ['Uus Läti-Eesti elektriliin võib tulla Liivi merepargi kaudu',
-        'https://www.err.ee/1036888/uus-lati-eesti-elektriliin-voib-tulla-liivi-merepargi-kaudu'],
-        ['Eesti koos veel kaheksa riigiga kaalub EL-i maanteepaketi tõttu kohtuteed',
-        'https://www.err.ee/1036795/eesti-koos-veel-kaheksa-riigiga-kaalub-el-i-maanteepaketi-tottu-kohtuteed'],
-        ["Belarus orders two more oil tankers via Lithuania's Klaipeda",
-        'https://www.baltictimes.com/belarus_orders_two_more_oil_tankers_via_lithuania_s_klaipeda/'],
-        ["Belarus orders two more oil tankers via Lithuania's Klaipeda",
-        'https://www.baltictimes.com/belarus_orders_two_more_oil_tankers_via_lithuania_s_klaipeda/'],
-        ['Utena brewery is the first in the country to eliminate CO 2 emissions: '
-        'exclusive status granted',
-        'https://www.baltictimes.com/utena_brewery_is_the_first_in_the_country_to_eliminate_co_2_emissions__exclusive_status_granted/'],
-        ['Lithuania chosen as a launchpad to EU markets – Cinganta',
-        'https://www.baltictimes.com/lithuania_chosen_as_a_launchpad_to_eu_markets___cinganta/'],
-        ['Two Latvian citizens convicted of large-scale fraud in the United States',
-        'https://www.baltictimes.com/two_latvian_citizens_convicted_of_large-scale_fraud_in_the_united_states/'],
-        ['Finanšu tehnoloģiju uzņēmumi nolūko Vjetnamu',
-        'https://www.db.lv/zinas/finansu-tehnologiju-uznemumi-noluko-vjetnamu-494934'],
-        ['Maksājumu jomā transformācija turpināsies',
-        'https://www.db.lv/zinas/maksajumu-joma-transformacija-turpinasies-494760'],
-        ['Elektroenerģijas ražotājs AS Residence Energy par labu Meridian Trade Bank '
-        'ieķīlājis visu mantu',
-        'https://www.db.lv/zinas/elektroenergijas-razotajs-as-residence-energy-par-labu-meridian-trade-bank-iekilajis-visu-mantu-494452'],
-        ['Kā top? Ziemeļu Enkurs alus',
-        'https://www.db.lv/zinas/ka-top-ziemelu-enkurs-alus-494781'],
-        ['Twitter ienākumi pārlec miljardam',
-        'https://www.db.lv/zinas/twitter-ienakumi-parlec-miljardam-494804']]
 
 class TranslateList():
     '''Based on googletrans Translator, tailored for project needs. Works on uniform language list only. Takes args:
@@ -63,7 +16,6 @@ class TranslateList():
         self.desired_lang_list = desired_lang_list
         self.expected_langs = ['en', 'et', 'lv', 'lt']
         self.detection_confidence = 0.9
-        self.sleep_time = 100
     
     def init_translator(self):
         '''get user agent, proxies & initialize Translator instance'''
@@ -99,7 +51,7 @@ class TranslateList():
                 continue
             if lang not in detected_langs:
                 detected_langs.append(lang)
-        logger.info(f'Returning first detected list language: {detected_langs[0]}, total detected languages in list: {len(detected_langs)}')
+        logger.info(f'Returning first detected list language: {detected_langs[0]}, all detected languages in list: {detected_langs}')
         return detected_langs[0]
 
     def delete_member(self, idx):
@@ -182,7 +134,4 @@ class TranslateList():
 
 
 if __name__ == '__main__':
-    # pass
-    translator = TranslateList(test_headline_data, ['en'])
-    translated_list = translator.get_translated()
-    pprint(translated_list)
+    pass

--- a/translate.py
+++ b/translate.py
@@ -99,9 +99,7 @@ class TranslateList():
                 continue
             if lang not in detected_langs:
                 detected_langs.append(lang)
-        if len(detected_langs) != 1:
-            logger.warning(f'Passed list contains more than one language. Detected languages contain: {detected_langs}')
-            raise Exception(f'Not processing this list. Language detection results: {detected_langs}')
+        logger.info(f'Returning first detected list language: {detected_langs[0]}, total detected languages in list: {len(detected_langs)}')
         return detected_langs[0]
 
     def delete_member(self, idx):
@@ -122,7 +120,7 @@ class TranslateList():
                     return None
                 self.init_translator()
                 logger.debug('---Before requesting google API---')
-                translation_objs = self.translator.translate(list_to_translate, src=src_lang ,dest=trg_lang)
+                translation_objs = self.translator.translate(list_to_translate, src='auto' ,dest=trg_lang)
                 logger.debug('---After requesting google API---')
                 return translation_objs
             except:
@@ -143,7 +141,7 @@ class TranslateList():
             raise Exception
 
     def lists_same_length(self, src_list, translated_list):
-        '''simply compared lengths of passed lists'''
+        '''returns True if passed lists contain same length'''
         return len(src_list) == len(translated_list)
 
     def construct_src_size_output(self, src_list, translated_list):
@@ -165,7 +163,7 @@ class TranslateList():
         logger.info(f'Calculated total number characters in passed headlines list is {chars}')
 
     def get_translated(self):
-        '''if possible, returns translated list'''        
+        '''if possible, returns translated list'''
         if self.desired_langs_supported():
             self.headlines = self.strip_src_to_headings()
             self.get_total_chars(self.headlines)


### PR DESCRIPTION
Solves #24 issue.

TranslateList class is still designed to use for uniform language across its members, however it solves the issue of mistakenly detected languages.

Detection is still present with the main function - to prevent querying googletrans library (thereby Google Translate API) if passed list headline data is already in the desired language.

Also removed sleep parameter, since proxy was [introduced](https://github.com/yomajo/Investor-Newsletter/commit/b118cb25d1366b84897b838d0a187ebfa3cb106f), 100s sleep between API calls makes no sense anymore.

**Possible improvements**:
Currently get_headlines_list_lang still returns first list item:
`return detected_langs[0]`

Improved way would be to collect detection results from all src_list members and return most frequent occurence.